### PR TITLE
Only one federate name can be appended to the "federateSequence" para…

### DIFF
--- a/foundation/rti-base/src/main/c++/InteractionRoot.cpp
+++ b/foundation/rti-base/src/main/c++/InteractionRoot.cpp
@@ -309,6 +309,7 @@ void InteractionRoot::unsubscribe_interaction(const std::string &hlaClassName, R
 }
 
 void InteractionRoot::initializeProperties(const std::string &hlaClassName) {
+    federateAppendedToFederateSequence = false;
     setInstanceHlaClassName(hlaClassName);
     if (get_hla_class_name_set().find(hlaClassName) == get_hla_class_name_set().end()) {
         BOOST_LOG_SEV(get_logger(), error)
@@ -572,7 +573,10 @@ void InteractionRoot::readFederateDynamicMessageClasses(std::istream &dynamicMes
             if (!typeDataMap["Hidden"].asBool()) {
                 const std::string propertyTypeString = typeDataMap["ParameterType"].asString();
                 get_class_and_property_name_initial_value_sp_map()[classAndPropertyName] =
-                  ValueSP( new Value(*get_type_initial_value_sp_map()[propertyTypeString]) );
+                  ValueSP( new Value(
+                    hlaClassName == "InteractionRoot.C2WInteractionRoot" && propertyName == "federateSequence" ?
+                      std::string("[]") : *get_type_initial_value_sp_map()[propertyTypeString]
+                  ) );
             }
         }
 

--- a/foundation/rti-base/src/main/c++/InteractionRoot_p/C2WInteractionRoot.cpp
+++ b/foundation/rti-base/src/main/c++/InteractionRoot_p/C2WInteractionRoot.cpp
@@ -34,9 +34,33 @@ namespace org {
   namespace hla {
    namespace InteractionRoot_p {
 
+bool C2WInteractionRoot::is_federate_sequence(const std::string &federateSequence) {
+    Json::Value jsonArray(Json::arrayValue);
+
+    std::istringstream jsonInputStream( federateSequence );
+    try {
+        jsonInputStream >> jsonArray;
+    } catch(...) {
+        return false;
+    }
+
+    int jsonArrayLength = jsonArray.size();
+    for(int ix = 0 ; ix < jsonArrayLength ; ++ix) {
+        if (!jsonArray[ix].isString()) {
+            return false;
+        }
+    }
+    return true;
+}
+
 void C2WInteractionRoot::update_federate_sequence_aux(
   ::org::cpswt::hla::InteractionRoot &interactionRoot, const std::string &federateId
 ) {
+    if (::org::cpswt::hla::InteractionRoot::get_federate_appended_to_federate_sequence(interactionRoot)) {
+        return;
+    }
+    ::org::cpswt::hla::InteractionRoot::set_federate_appended_to_federate_sequence(interactionRoot);
+
     std::string federateSequence = interactionRoot.getParameter("federateSequence").asString();
 
     Json::Value jsonArray(Json::arrayValue);
@@ -105,7 +129,7 @@ bool C2WInteractionRoot::static_init() {
     );
 
     get_class_and_property_name_initial_value_sp_map()[ClassAndPropertyName( "InteractionRoot.C2WInteractionRoot", "federateSequence" )] =
-      ValueSP( new Value( std::string("") ));
+      ValueSP( new Value( std::string("[]") ));
 
     // ADD THIS CLASS'S _classAndPropertyNameSet TO _classNamePropertyNameSetMap DEFINED
     // IN InteractionRoot

--- a/foundation/rti-base/src/main/include/InteractionRoot.hpp
+++ b/foundation/rti-base/src/main/include/InteractionRoot.hpp
@@ -178,6 +178,17 @@ protected:
         _instanceHlaClassName = instanceHlaClassName;
     }
 
+    // FOR INTERACTIONS DERIVED FROM InteractionRoot.C2WInteractionRoot
+    bool federateAppendedToFederateSequence;
+
+    static void set_federate_appended_to_federate_sequence(InteractionRoot &interactionRoot) {
+        interactionRoot.federateAppendedToFederateSequence = true;
+    }
+
+    static bool get_federate_appended_to_federate_sequence(const InteractionRoot &interactionRoot) {
+        return interactionRoot.federateAppendedToFederateSequence;
+    }
+
 public:
     static std::string get_simple_class_name(const std::string &hlaClassName) {
         size_t position = hlaClassName.find_last_of('.');

--- a/foundation/rti-base/src/main/include/InteractionRoot_p/C2WInteractionRoot.hpp
+++ b/foundation/rti-base/src/main/include/InteractionRoot_p/C2WInteractionRoot.hpp
@@ -36,8 +36,6 @@
 
 #include <list>
 
-#include <boost/regex.hpp>
-
 #include <boost/unordered_set.hpp>
 
 
@@ -422,16 +420,7 @@ public:
     // END INSTANCE CREATION METHODS
     //------------------------------
 private:
-    static boost::regex &get_federate_sequence_regex() {
-        static boost::regex federateSequenceRegex(
-          "\\s*\\[(?:\\s*\"(?:[^\"]|(?:\\\\)*\\\")+\",)*\\s*\"(?:[^\"]|(?:\\\\)*\\\")+\"\\s*\\]\\s*"
-        );
-        return federateSequenceRegex;
-    }
-
-    static bool is_federate_sequence(const std::string &federateSequence) {
-        return boost::regex_match( federateSequence, get_federate_sequence_regex() );
-    }
+    static bool is_federate_sequence(const std::string &federateSequence);
 
     static void update_federate_sequence_aux(::org::cpswt::hla::InteractionRoot &interactionRoot, const std::string &federateId);
     static StringList get_federate_sequence_list_aux(const ::org::cpswt::hla::InteractionRoot &interactionRoot);

--- a/foundation/rti-base/src/test/include/MessagingTests.hpp
+++ b/foundation/rti-base/src/test/include/MessagingTests.hpp
@@ -81,6 +81,7 @@ private:
     CPPUNIT_TEST(dynamicMessagingTest);
     CPPUNIT_TEST(valueTest);
     CPPUNIT_TEST(messagingInstanceHlaClassTest);
+    CPPUNIT_TEST(federateSequenceTest);
     CPPUNIT_TEST(printInteractionTest);
     CPPUNIT_TEST_SUITE_END();
 
@@ -106,6 +107,7 @@ public:
     void dynamicMessagingTest();
     void valueTest();
     void messagingInstanceHlaClassTest();
+    void federateSequenceTest();
     void printInteractionTest();
 };
 


### PR DESCRIPTION
…meter of an interaction derived from "InteractionRoot.C2WInteractionRoot" -- attempts to add more federate name fail silently.